### PR TITLE
Expose parameters in manifest in the ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ automatically configured with l2 and l3 rules for routing traffic to all hosts
   ],
   "hosts": {
     "h1": {
-      "cmd": "python echo_server.py %port%",
+      "cmd": "python echo_server.py $port",
       "startup_sleep": 0.2,
       "wait": false
     },
     "h2": {
-      "cmd": "python echo_client.py h1 %port% %echo_msg%",
+      "cmd": "python echo_client.py h1 $port $echo_msg",
       "wait": true
     }
   },
@@ -231,9 +231,9 @@ with the following options:
  - `latency` - the latency between this host and the switch. This can either be a number (interpreted as seconds) or a string with time units (e.g. `50ms` or `1s`). This overrides the latency set in the `links` object.
 
 The command is formatted by replacing the hostnames (e.g. `h1`) with the
-corresponding IP address, and the parameters (surrounded by '%', e.g.
-`%port%`) with their corresponding values. The parameters should be defined in
-the multiswitch target in the manifest. For example, have a look at the
+corresponding IP address. The parameters specified in the target will be
+available to the command as environment variables (i.e. `$` followed by the
+variable name). For an example, have a look at the
 [manifest](examples/multiswitch.p4app/p4app.json) for the multiswitch example
 app.
 

--- a/docker/scripts/mininet/multi_switch_mininet.py
+++ b/docker/scripts/mininet/multi_switch_mininet.py
@@ -22,6 +22,7 @@ import subprocess
 import argparse
 import json
 import importlib
+import re
 from time import sleep
 
 from mininet.net import Mininet
@@ -85,7 +86,7 @@ def main():
 
     def formatParams(s):
         for param in params:
-            s = s.replace('$'+param, str(params[param]))
+            s = re.sub('\$'+param+'(\W|$)', str(params[param]) + r'\1', s)
             s = s.replace('${'+param+'}', str(params[param]))
         return s
 
@@ -162,7 +163,6 @@ def main():
 
 
     def formatCmd(cmd):
-        cmd = formatParams(cmd)
         for h in net.hosts:
             cmd = cmd.replace(h.name, h.defaultIntf().updateIP())
         return cmd

--- a/docker/scripts/mininet/multi_switch_mininet.py
+++ b/docker/scripts/mininet/multi_switch_mininet.py
@@ -85,7 +85,8 @@ def main():
 
     def formatParams(s):
         for param in params:
-            s = s.replace('{'+param+'}', str(params[param]))
+            s = s.replace('$'+param, str(params[param]))
+            s = s.replace('${'+param+'}', str(params[param]))
         return s
 
     AppTopo = apptopo.AppTopo

--- a/examples/customtopo.p4app/p4app.json
+++ b/examples/customtopo.p4app/p4app.json
@@ -9,12 +9,12 @@
       "links": [["h1", "s1"], ["s1", "s2"], ["s2", "h2", 50]],
       "hosts": {
         "h1": {
-            "cmd": "python echo_server.py %port%",
+            "cmd": "python echo_server.py $port",
             "startup_sleep": 0.2,
             "wait": false
         },
         "h2": {
-            "cmd": "python echo_client.py h1 %port% %echo_msg%",
+            "cmd": "python echo_client.py h1 $port $echo_msg",
             "wait": true
         }
       },

--- a/examples/multi_iface.p4app/p4app.json
+++ b/examples/multi_iface.p4app/p4app.json
@@ -4,20 +4,20 @@
   "targets": {
       "multiswitch": {
       "auto-control-plane": true,
-      "links": [["h1", "s1"], ["h2", "s2"], ["h3", "s1"], ["h3", "s2", "%mylatency%ms"]],
+      "links": [["h1", "s1"], ["h2", "s2"], ["h3", "s1"], ["h3", "s2", "{mylatency}ms"]],
       "hosts": {
         "h1": {
-            "cmd": "python echo_server.py %port%",
+            "cmd": "python echo_server.py $port",
             "startup_sleep": 0.2,
             "wait": false
         },
         "h2": {
-            "cmd": "python echo_server.py %port%",
+            "cmd": "python echo_server.py $port",
             "startup_sleep": 0.2,
             "wait": false
         },
         "h3": {
-            "cmd": "python echo_client.py %echo_msg% h1 %port% h2 %port%",
+            "cmd": "python echo_client.py $echo_msg h1 $port h2 $port",
             "wait": true
         }
       },

--- a/examples/multi_iface.p4app/p4app.json
+++ b/examples/multi_iface.p4app/p4app.json
@@ -4,7 +4,7 @@
   "targets": {
       "multiswitch": {
       "auto-control-plane": true,
-      "links": [["h1", "s1"], ["h2", "s2"], ["h3", "s1"], ["h3", "s2", "{mylatency}ms"]],
+      "links": [["h1", "s1"], ["h2", "s2"], ["h3", "s1"], ["h3", "s2", "${mylatency}ms"]],
       "hosts": {
         "h1": {
             "cmd": "python echo_server.py $port",

--- a/examples/multiswitch.p4app/p4app.json
+++ b/examples/multiswitch.p4app/p4app.json
@@ -7,12 +7,12 @@
       "links": [["h1", "s1"], ["s1", "s2"], ["s2", "h2", 50]],
       "hosts": {
         "h1": {
-            "cmd": "python echo_server.py %port%",
+            "cmd": "python echo_server.py $port",
             "startup_sleep": 0.2,
             "wait": false
         },
         "h2": {
-            "cmd": "python echo_client.py h1 %port% %echo_msg%",
+            "cmd": "python echo_client.py h1 $port $echo_msg",
             "wait": true
         }
       },


### PR DESCRIPTION
When executing commands on mininet hosts, the parameters set in the manifest will be available in the environment. To achieve this, we now execute commands in a shell (shell=True), so we have to use pkill to kill the whole process group. 