### PR TITLE
Fix call to super

### DIFF
--- a/docker/scripts/mininet/p4_mininet.py
+++ b/docker/scripts/mininet/p4_mininet.py
@@ -24,7 +24,7 @@ import socket
 
 class P4Host(Host):
     def config(self, **params):
-        r = super(Host, self).config(**params)
+        r = super(P4Host, self).config(**params)
 
         for off in ["rx", "tx", "sg"]:
             cmd = "/sbin/ethtool --offload %s %s off" % (self.defaultIntf().name, off)


### PR DESCRIPTION
It's a bit pedantic, but needed fixing. I came across this when extending the `P4Host` class for a VLAN example. Before this fix the mininet.node.Host's config method would have been skipped (had it existed).