### PR TITLE
Specify log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,3 +421,17 @@ directory. If your manifest file is not called `p4app.json`, you can use the
 ```
 p4app run myapp.p4app --manifest testing.p4app
 ```
+
+#### Specify location of log directory
+By default, p4app will mount the directory `/tmp/p4app_logs` on the host to
+`/tmp/p4app_logs` on the docker container guest. The output from bmv2, as well
+as any output from your programs, will be saved to this directory.  Instead of
+using the default directory (`/tmp/p4app_logs`), you can specify another
+directory with the `$P4APP_LOGDIR` environment variable. For example, if you
+run:
+
+```
+P4APP_LOGDIR=./out p4app run myapp.p4app
+```
+
+all the log files will be stored to `./out`.

--- a/p4app
+++ b/p4app
@@ -15,6 +15,8 @@
 
 P4APP_IMAGE=${P4APP_IMAGE:-p4lang/p4app:stable}
 
+P4APP_LOGDIR=$(readlink -f "${P4APP_LOGDIR:-/tmp/p4app_logs}")
+
 function get_abs_filename() {
   # Convert a possibly-relative path to an absolute path.
   echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
@@ -29,7 +31,7 @@ function run-p4app {
   APP_TO_RUN=/tmp/app.tar.gz
   docker run --privileged --interactive --tty --rm \
             -v $1:$APP_TO_RUN \
-            -v /tmp/p4app_logs:/tmp/p4app_logs \
+            -v "$P4APP_LOGDIR":/tmp/p4app_logs \
              $P4APP_IMAGE $APP_TO_RUN "${@:2}"
 }
 


### PR DESCRIPTION
As explained in README:
#### Specify location of log directory
By default, p4app will mount the directory `/tmp/p4app_logs` on the host to
`/tmp/p4app_logs` on the docker container guest. The output from bmv2, as well
as any output from your programs, will be saved to this directory.  Instead of
using the default directory (`/tmp/p4app_logs`), you can specify another
directory with the `$P4APP_LOGDIR` environment variable. For example, if you
run:

```
P4APP_LOGDIR=./out p4app run myapp.p4app
```

all the log files will be stored to `./out`.