### PR TITLE
Fix: simple switch is started with pcap and log console args

### DIFF
--- a/docker/scripts/mininet/multi_switch_mininet.py
+++ b/docker/scripts/mininet/multi_switch_mininet.py
@@ -133,8 +133,8 @@ def main():
     switchClass = configureP4Switch(
             sw_path=args.behavioral_exe,
             json_path=args.json,
-            log_console=args.bmv2_log,
-            pcap_dump=args.pcap_dump)
+            log_console=bmv2_log,
+            pcap_dump=pcap_dump)
     net = Mininet(topo = topo,
                   link = TCLink,
                   host = P4Host,


### PR DESCRIPTION
There was a bug in the multiswitch target that prevented the manifest from configuring the `--pcap` and `--log-console` params that are passed to the simple switch.