### PR TITLE
Mininet hosts have a different IP address for each interface

### DIFF
--- a/docker/scripts/mininet/appcontroller.py
+++ b/docker/scripts/mininet/appcontroller.py
@@ -77,7 +77,6 @@ class AppController:
             if sw not in self.entries: self.entries[sw] = []
             if 'switches' not in self.conf or sw not in self.conf['switches'] or 'entries' not in self.conf['switches'][sw]:
                 continue
-            print "-----------------------"
             extra_entries = self.conf['switches'][sw]['entries']
             if type(extra_entries) == list: # array of entries
                 self.entries[sw] += extra_entries
@@ -87,12 +86,6 @@ class AppController:
     def generate_default_entries(self):
         for sw in self.topo.switches():
             if sw not in self.entries: self.entries[sw] = []
-            if 'switches' in self.conf and sw in self.conf['switches'] and 'entries' in self.conf['switches'][sw]:
-                extra_entries = self.conf['switches'][sw]['entries']
-                if type(extra_entries) == list: # array of entries
-                    self.entries[sw] += extra_entries
-                else: # path to file that contains entries
-                    self.entries[sw] += self.read_entries(extra_entries)
             self.entries[sw] += [
                 'table_set_default send_frame _drop',
                 'table_set_default forward _drop',

--- a/docker/scripts/mininet/apptopo.py
+++ b/docker/scripts/mininet/apptopo.py
@@ -30,9 +30,6 @@ class AppTopo(Topo):
         for host_name in host_names:
             host_num = host_names.index(host_name)+1
 
-            host_ip = "10.0.%d.10" % host_num
-            host_mac = '00:04:00:00:00:%02x' % host_num
-
             self.addHost(host_name)
 
             self._host_links[host_name] = {}
@@ -44,13 +41,15 @@ class AppTopo(Topo):
                 assert sw in sw_names, "Hosts should be connected to switches, not " + str(sw)
                 sw_num = sw_names.index(sw)+1
 
+                host_mac = '00:04:00:00:%02x:%02x' % (host_num, sw_idx+1)
+
                 delay_key = tuple(sorted([host_name, sw]))
                 delay = self.conf['latencies'][delay_key] if delay_key in self.conf['latencies'] else '0ms'
                 self._port_map[sw][host_name] = len(self._port_map[sw])+1
                 self._host_links[host_name][sw] = dict(
                         idx=sw_idx,
                         host_mac = host_mac,
-                        host_ip = host_ip,
+                        host_ip = "10.0.%d.%d" % (host_num, 100+sw_idx+1),
                         sw = sw,
                         sw_mac = "00:aa:00:%02x:00:%02x" % (sw_num, host_num),
                         sw_ip = "10.0.%d.%d" % (host_num, sw_idx+1),


### PR DESCRIPTION
Before, each host in the mininet multiswitch network had one IP address. With this change, each interface has a unique IP address (and MAC).