### PR TITLE
Update to use p4lang/p4c:latest rather than p4lang/p4c:stable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM p4lang/p4c:stable
+FROM p4lang/p4c:latest
 MAINTAINER Seth Fowler <seth@barefootnetworks.com>
 MAINTAINER Robert Soule <robert.soule@barefootnetworks.com>
 

--- a/examples/compile_only.p4app/p4app.json
+++ b/examples/compile_only.p4app/p4app.json
@@ -3,7 +3,7 @@
   "language": "p4-14",
   "targets": {
     "compile-bmv2": {
-      "compiler-flags": ["-v", "--p4runtime-file out.bin", "--p4runtime-as-json"],
+      "compiler-flags": ["-v", "--p4runtime-file out.bin", "--p4runtime-format json"],
       "run-after-compile": ["cat out.bin"]
     }
   }

--- a/examples/paxos_acceptor.p4app/includes/header.p4
+++ b/examples/paxos_acceptor.p4app/includes/header.p4
@@ -3,7 +3,7 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-typedef bit<4> PortId;
+typedef bit<9> PortId;
 
 // Physical Ports
 const PortId DROP_PORT = 0xF;


### PR DESCRIPTION
Update to use p4lang/p4c:latest rather than p4lang/p4c:stable, which doesn't seem to exist ("fixes #20").