### PR TITLE
Fixes for issues 20, 21, and 24.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM p4lang/p4c:stable
+FROM p4lang/p4c:latest
 MAINTAINER Seth Fowler <seth@barefootnetworks.com>
 MAINTAINER Robert Soule <robert.soule@barefootnetworks.com>
 

--- a/examples/compile_only.p4app/p4app.json
+++ b/examples/compile_only.p4app/p4app.json
@@ -3,7 +3,7 @@
   "language": "p4-14",
   "targets": {
     "compile-bmv2": {
-      "compiler-flags": ["-v", "--p4runtime-file out.bin", "--p4runtime-as-json"],
+      "compiler-flags": ["-v", "--p4runtime-file out.bin", "--p4runtime-format json"],
       "run-after-compile": ["cat out.bin"]
     }
   }

--- a/examples/paxos_acceptor.p4app/includes/header.p4
+++ b/examples/paxos_acceptor.p4app/includes/header.p4
@@ -3,7 +3,7 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-typedef bit<4> PortId;
+typedef bit<9> PortId;
 
 // Physical Ports
 const PortId DROP_PORT = 0xF;


### PR DESCRIPTION
This PR includes the following changes:

1. Change the Dockerfile to reference p4c:latest instead of p4c:stable (fixes #20).
2. Change the compiler flags in the compile_only example (fixes #21).
3. Change the width of the PortId variable in paxos_acceptor ( fixes #24 ).

Since all of the changes are minor, I thought it would be okay to group them into a single PR.
