### PR TITLE
Added module for running processes on mininet hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ app.
 Currently, each host can be connected to at most one switch.
 
 
-#### Specifying entries for each switch
+#### Specifying entries (commands) for each switch
 The routing tables (`ipv4_lpm`, `send_frame` and `forward`) are automatically
-populated with this target. Additionally, you can specify custom entries to be
-added to each switch. You can either include a commands file, or an array of
-entries. These custom entries will have precedence over the automatically
+populated with this target. Additionally, you can specify custom commands to be
+run on each switch. You can either include a commands file, or an array of
+commands. These custom commands will be sent before the automatically
 generated ones for the routing tables. For example:
 
 ```
@@ -254,10 +254,10 @@ generated ones for the routing tables. For example:
   "hosts": { ... },
   "switches": {
     "s1": {
-      "entries": "s1_commands.txt"
+      "commands": "s1_commands.txt"
     },
     "s2": {
-      "entries": [
+      "commands": [
         "table_add ipv4_lpm set_nhop 10.0.1.10/32 => 10.0.1.10 1",
         "table_add ipv4_lpm set_nhop 10.0.2.10/32 => 10.0.2.10 2"
       ]
@@ -266,9 +266,9 @@ generated ones for the routing tables. For example:
 }
 ```
 
-If the entries for `s2` above overlap with the automatically generated entries
+If the commands for `s2` above overlap with the automatically generated commands
 (e.g. there is an automatic entry for `set_nhop 10.0.1.10/32`), these custom
-entries will have precedence and you will see a warning about a duplicate entry
+commands will have precedence and you will see a warning about a duplicate entry
 while the tables are being populated.
 
 #### Custom topology class

--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ Similarly to the `topo_module` option, you can specify a controller with the
 extend this class, as shown in the
 [customtopo.p4app](examples/customtopo.p4app/mycontroller.py) example.
 
+### Custom host process runner
+The AppProcRunner class is responsible for executing programs in each of the
+mininet hosts. By specifying the `controller_module` option, you can override
+the default behaviour for launching and killing programs on the hosts. This
+module should implement the class `CustomAppProcRunner`. The default controller
+class is
+[appprocrunner.AppProcRunner](docker/scripts/mininet/appprocrunner.py). You can
+extend this class, as shown in the
+[customtopo.p4app](examples/customtopo.p4app/myprocrunner.py) example.
+
 
 #### Logging
 When this target is run, a temporary directory on the host, `/tmp/p4app_log`,

--- a/docker/scripts/mininet/appprocrunner.py
+++ b/docker/scripts/mininet/appprocrunner.py
@@ -1,0 +1,133 @@
+from time import sleep
+import os
+
+class AppProcess:
+
+    def __init__(self, runner, host, host_conf):
+        self.runner = runner
+        self.host = host
+        self.host_conf = host_conf
+        self.proc = None
+        self.stdout_file = None
+        self.stdout_filename = os.path.join(self.runner.log_dir, self.host.name + '.stdout')
+
+    def isDaemon(self):
+        if 'wait' in self.host_conf and self.host_conf['wait']:
+            return False
+        return True
+
+    def formatCmd(self, cmd):
+        for h in self.runner.net.hosts:
+            cmd = cmd.replace(h.name, h.defaultIntf().updateIP())
+        return cmd
+
+
+    def start(self):
+        self.stdout_file = open(self.stdout_filename, 'w')
+        self.cmd = self.formatCmd(self.host_conf['cmd'])
+        self.proc = self.host.popen(self.cmd, stdout=self.stdout_file, shell=True, preexec_fn=os.setpgrp)
+
+        print self.host.name, self.cmd
+
+        if 'startup_sleep' in self.host_conf:
+            sleep(self.host_conf['startup_sleep'])
+
+    def cleanup(self):
+        if self.stdout_file:
+            self.stdout_file.flush()
+            self.stdout_file.close()
+
+    def waitForExit(self):
+        print self.proc.communicate()
+        if self.proc.returncode is None:
+            self.proc.wait()
+            print self.proc.communicate()
+
+        self.cleanup()
+
+        return self.proc.returncode
+
+
+    def kill(self):
+        if self.proc.returncode is not None: # already exited
+            return self.proc.returncode
+
+        run_command('pkill -INT -P %d' % self.proc.pid)
+        sleep(0.2)
+        rc = run_command('pkill -0 -P %d' % self.proc.pid) # check if it's still running
+        if rc == 0: # the process group is still running, send TERM
+            sleep(1) # give it a little more time to exit gracefully
+            run_command('pkill -TERM -P %d' % self.proc.pid)
+        return self.proc.returncode
+
+def run_command(command):
+    return os.WEXITSTATUS(os.system(command))
+
+
+class AppProcRunner:
+
+    def __init__(self, manifest=None, target=None, topo=None, net=None, log_dir=None):
+        self.manifest = manifest
+        self.target = target
+        self.conf = manifest['targets'][target]
+        self.topo = topo
+        self.net = net
+        self.log_dir = log_dir
+        self.AppProcessClass = AppProcess
+
+        self.app_procs = []
+        self.foreground_procs, self.background_procs = [], []
+        self.return_codes = []
+
+    def setupProcs(self):
+        os.environ.update(dict(map(lambda (k,v): (k, str(v)), self.conf['parameters'].iteritems())))
+        print '\n'.join(map(lambda (k,v): "%s: %s"%(k,v), self.conf['parameters'].iteritems())) + '\n'
+
+        for host_name in sorted(self.conf['hosts'].keys()):
+            host_conf = self.conf['hosts'][host_name]
+            if 'cmd' not in host_conf: continue
+
+            p = self.AppProcessClass(self, self.net.get(host_name), host_conf)
+            self.app_procs.append(p)
+
+    def startAllProcs(self):
+        for p in self.app_procs:
+            p.start()
+
+            if p.isDaemon():
+                self.background_procs.append(p)
+            else:
+                self.foreground_procs.append(p)
+
+    def waitForForegroundProcs(self):
+        for p in self.foreground_procs:
+            rc = p.waitForExit()
+            self.return_codes.append(rc)
+
+    def killBackgroundProcs(self):
+        for p in self.background_procs:
+            p.kill()
+            rc = p.waitForExit()
+            self.return_codes.append(rc)
+
+    def runAfterCmds(self):
+        if 'after' in self.conf and 'cmd' in self.conf['after']:
+            cmds = self.conf['after']['cmd'] if type(self.conf['after']['cmd']) == list else [self.conf['after']['cmd']]
+            for cmd in cmds:
+                os.system(cmd)
+
+    def runall(self):
+        self.setupProcs()
+
+        self.startAllProcs()
+
+        self.waitForForegroundProcs()
+
+        self.killBackgroundProcs()
+
+        self.runAfterCmds()
+
+    def hadError(self):
+        bad_codes = [rc for rc in self.return_codes if rc != 0]
+        if len(bad_codes): return True
+        return False

--- a/examples/broadcast.p4app/header.p4
+++ b/examples/broadcast.p4app/header.p4
@@ -6,10 +6,10 @@ struct ingress_metadata_t {
 }
 
 struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
     bit<16> mcast_grp;
     bit<16> egress_rid;
+    bit<48> ingress_global_timestamp;
+    bit<32> lf_field_list;
 }
 
 header ethernet_t {

--- a/examples/broadcast.p4app/p4app.json
+++ b/examples/broadcast.p4app/p4app.json
@@ -25,7 +25,7 @@
       },
       "switches": {
           "s1": {
-              "entries": "commands.txt"
+              "commands": "commands.txt"
           }
       }
     }

--- a/examples/customtopo.p4app/mycontroller.py
+++ b/examples/customtopo.p4app/mycontroller.py
@@ -10,7 +10,7 @@ class CustomAppController(AppController):
         AppController.start(self)
 
     def stop(self):
-        reg_val = self.read_register('forward_count_register', 0)
+        reg_val = self.readRegister('forward_count_register', 0)
         print "The switch forwarded a total of %d packets" % reg_val
         AppController.stop(self)
 

--- a/examples/customtopo.p4app/myprocrunner.py
+++ b/examples/customtopo.p4app/myprocrunner.py
@@ -1,0 +1,17 @@
+from appprocrunner import AppProcRunner, AppProcess
+
+class CustomAppProccess(AppProcess):
+    def __init__(self, *args, **kwargs):
+        AppProcess.__init__(self, *args, **kwargs)
+
+    def formatCmd(self, raw_cmd):
+        print "cmd before formatting:", raw_cmd
+        cmd = AppProcess.formatCmd(self, raw_cmd)
+        print "cmd after formatting:", cmd
+        return cmd
+
+class CustomAppProcRunner(AppProcRunner):
+
+    def __init__(self, *args, **kwargs):
+        AppProcRunner.__init__(self, *args, **kwargs)
+        self.AppProcessClass = CustomAppProccess

--- a/examples/customtopo.p4app/p4app.json
+++ b/examples/customtopo.p4app/p4app.json
@@ -5,6 +5,7 @@
       "multiswitch": {
       "topo_module": "mytopo",
       "controller_module": "mycontroller",
+      "procrunner_module": "myprocrunner",
       "auto-control-plane": true,
       "links": [["h1", "s1"], ["s1", "s2"], ["s2", "h2", 50]],
       "hosts": {


### PR DESCRIPTION
Straight from the README:

The AppProcRunner class is responsible for executing programs in each of the mininet hosts. By specifying the `controller_module` option, you can override the default behaviour for launching and killing programs on the hosts. This module should implement the class `CustomAppProcRunner`. The default controller class is [appprocrunner.AppProcRunner](docker/scripts/mininet/appprocrunner.py). You can
extend this class, as shown in the [customtopo.p4app](examples/customtopo.p4app/myprocrunner.py) example.