### PR TITLE
Ignore interactive prompts from apt-get when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ ENV MININET_DEPS automake \
                  pylint \
                  python-pexpect \
                  python-setuptools
+
+# Ignore questions when installing with apt-get:
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $NET_TOOLS $MININET_DEPS
 


### PR DESCRIPTION
When building the Docker image, apt-get may present interactive prompts for configuring the programs it's installing. That blocks the installation process, and prevents the image from being built. This fix sets an environment variable that tells apt-get to not present interactive prompts.