### PR TITLE
[Need discuss] Add pcap_dump for single_switch_mininet

### DIFF
--- a/docker/scripts/mininet/single_switch_mininet.py
+++ b/docker/scripts/mininet/single_switch_mininet.py
@@ -39,7 +39,7 @@ parser.add_argument('--json', help='Path to JSON config file',
 parser.add_argument('--log-file', help='Path to write the switch log file',
                     type=str, action="store", required=False)
 parser.add_argument('--pcap-dump', help='Dump packets on interfaces to pcap files',
-                    type=str, action="store", required=False, default=False)
+                   action="store_true")
 parser.add_argument('--switch-config', help='simple_switch_CLI script to configure switch',
                     type=str, action="store", required=False, default=False)
 parser.add_argument('--cli-message', help='Message to print before starting CLI',
@@ -127,6 +127,9 @@ def main():
 
     CLI( net )
     net.stop()
+
+    if pcap_dump:
+        os.system('bash -c "cp *.pcap \'%s\'"' % '/tmp/p4app_logs')
 
 if __name__ == '__main__':
     setLogLevel( 'info' )

--- a/docker/scripts/p4apprunner.py
+++ b/docker/scripts/p4apprunner.py
@@ -178,6 +178,9 @@ def run_mininet(manifest):
 
     switch_args.append('--cli-message "%s"' % message_file)
 
+    if 'pcap_dump' in manifest.target_config and manifest.target_config['pcap_dump']:
+        switch_args.append('--pcap-dump')
+
     if 'num-hosts' in manifest.target_config:
         switch_args.append('--num-hosts %s' % manifest.target_config['num-hosts'])
 


### PR DESCRIPTION
single_switch_mininet.py didn't use `pcap_dump` option, so I try to fix it.
And it seems realize bmv2_log using log_file, but doesn't copy it from docker image.

I am not sure how to copy file from docker to host.
