### PR TITLE
Allow passing arguments to the p4app container

### DIFF
--- a/p4app
+++ b/p4app
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 P4APP_IMAGE=${P4APP_IMAGE:-p4lang/p4app:latest}
+P4APP_CONTAINER_ARGS=${P4APP_CONTAINER_ARGS:-""}
 
 
 myrealpath() {
@@ -54,6 +55,7 @@ function run-p4app {
             --name "p4app_$RANDOM" \
             -v $1:$APP_TO_RUN \
             -v "$P4APP_LOGDIR":/tmp/p4app_logs \
+             $P4APP_CONTAINER_ARGS \
              $P4APP_IMAGE $APP_TO_RUN "${@:2}"
 }
 


### PR DESCRIPTION
In some cases, it is desired to pass parameters to the p4app container,
e.g. loading volumes, or connecting it to specific network.

This change adds an environment variable that allows that.