### PR TITLE
Support "expect no packets" in STF

### DIFF
--- a/docker/scripts/stf/bmv2stf.py
+++ b/docker/scripts/stf/bmv2stf.py
@@ -387,6 +387,9 @@ class RunBMV2(object):
                 data = ''.join(data.split())
             if data != '':
                 self.expected.setdefault(interface, []).append(data)
+            else:
+                # No data provided: expect 0 packets on this intf.
+                self.expected.setdefault(interface, [])
         else:
             if self.options.verbose:
                 print("ignoring stf command:", first, cmd)


### PR DESCRIPTION
Specifying `expect 1` as an STF statement will tell the test runner to
expect 0 packets to appear on interface 1. Any packets that egress
interface 1 will cause an error. This is useful for test cases that
explicitly should not generate packets -- e.g. for filtering programs.

I'm using this STF fragment (and others like it) to test a P4 filtering
program in a 3 host network:

```
expect 0
expect 1
expect 2
packet 0 00aabb000001 000400000001 0800 45 00 003c ace3 4000 40 06 8fd6 0a00010a 0a00020a 5432 0050 15841ac1 00000000 a0 02 aaaa fe30 0204ffd7 0402 080a9b68b62200000000 01 030307
```

The given packet is dropped by the program, and the `expect` statements are explicitly testing that nothing comes out any of the interfaces. I also verified that `expect` statements with data specified still function as before.