### PR TITLE
Example: read and write registers

### DIFF
--- a/examples/registers.p4app/main.py
+++ b/examples/registers.p4app/main.py
@@ -1,0 +1,28 @@
+from p4app import P4Mininet
+from mininet.topo import SingleSwitchTopo
+
+topo = SingleSwitchTopo(2)
+net = P4Mininet(program='registers.p4', topo=topo)
+net.start()
+
+h1 = net.get('h1')
+
+out = h1.cmd('./send.py 10.0.0.2 write 1 4')
+assert out.strip() == "1 4"
+
+out = h1.cmd('./send.py 10.0.0.2 write 1 5')
+assert out.strip() == "1 5"
+
+out = h1.cmd('./send.py 10.0.0.2 read 1')
+assert out.strip() == "1 5"
+
+out = h1.cmd('./send.py 10.0.0.2 write 2 11')
+assert out.strip() == "2 11"
+
+# XXX GRPC errors with "Register reads are not supported yet"
+# TODO: test this once there's support for reading registers with p4runtime
+#s1 = net.get('s1')
+#print "about to read reg"
+#print s1.readRegister('myReg', 1)
+
+print "OK"

--- a/examples/registers.p4app/registers.p4
+++ b/examples/registers.p4app/registers.p4
@@ -1,0 +1,184 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4    = 0x800;
+const bit<8>  IP_PROT_UDP  = 0x11;
+
+const bit<8>  OP_READ_REG  = 0x1;
+const bit<8>  OP_WRITE_REG = 0x2;
+const bit<16> UDP_PORT     = 1234;
+
+typedef bit<9>  egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+header udp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<16> length_;
+    bit<16> checksum;
+}
+
+header myHdr_t {
+    bit<8>  opType;
+    bit<8>  idx;
+    bit<32> val;
+}
+
+struct metadata { }
+
+struct headers {
+    ethernet_t        ethernet;
+    ipv4_t            ipv4;
+    udp_t             udp;
+    myHdr_t           myHdr;
+}
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            IP_PROT_UDP: parse_udp;
+            default: accept;
+        }
+    }
+
+    state parse_udp {
+        packet.extract(hdr.udp);
+        transition select(hdr.udp.dstPort) {
+            UDP_PORT: parse_myHdr;
+            default : accept;
+        }
+    }
+
+    state parse_myHdr {
+        packet.extract(hdr.myHdr);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply { }
+}
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+
+    register<bit<32>>(128) myReg;
+
+    action reply() {
+        standard_metadata.egress_spec = standard_metadata.ingress_port;
+
+        macAddr_t tmpDstMac = hdr.ethernet.dstAddr;
+        hdr.ethernet.dstAddr = hdr.ethernet.srcAddr;
+        hdr.ethernet.srcAddr = tmpDstMac;
+
+        ip4Addr_t tmpDstIp = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = tmpDstIp;
+
+        bit<16> tmpDstPort = hdr.udp.dstPort;
+        hdr.udp.dstPort = hdr.udp.srcPort;
+        hdr.udp.srcPort = tmpDstPort;
+        hdr.udp.checksum = 0;
+
+    }
+
+
+    apply {
+
+        if (hdr.myHdr.isValid()) {
+            if (hdr.myHdr.opType == OP_READ_REG) {
+                myReg.read(hdr.myHdr.val, (bit<32>)hdr.myHdr.idx);
+            }
+            else if (hdr.myHdr.opType == OP_WRITE_REG) {
+                myReg.write((bit<32>)hdr.myHdr.idx, hdr.myHdr.val);
+            }
+        }
+
+        reply();
+
+    }
+}
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+     apply {
+	update_checksum(
+	    hdr.ipv4.isValid(),
+            { hdr.ipv4.version,
+	      hdr.ipv4.ihl,
+              hdr.ipv4.diffserv,
+              hdr.ipv4.totalLen,
+              hdr.ipv4.identification,
+              hdr.ipv4.flags,
+              hdr.ipv4.fragOffset,
+              hdr.ipv4.ttl,
+              hdr.ipv4.protocol,
+              hdr.ipv4.srcAddr,
+              hdr.ipv4.dstAddr },
+            hdr.ipv4.hdrChecksum,
+            HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.udp);
+        packet.emit(hdr.myHdr);
+    }
+}
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/examples/registers.p4app/send.py
+++ b/examples/registers.p4app/send.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import sys
+import socket
+import struct
+
+UDP_PORT = 1234
+OP_READ  = 1
+OP_WRITE = 2
+
+hdr = struct.Struct('!B B I') # op_type idx [val]
+
+if len(sys.argv) < 4:
+    print "Usage: %s HOST READ|WRITE IDX [VALUE]" % sys.argv[0]
+    sys.exit(1)
+
+host = sys.argv[1]
+read_or_write = sys.argv[2].lower()[:1]
+idx = int(sys.argv[3])
+
+addr = (host, UDP_PORT)
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+if read_or_write == 'r':
+    req = hdr.pack(OP_READ, idx, 0)
+else:
+    assert len(sys.argv) == 5
+    val = int(sys.argv[4])
+    req = hdr.pack(OP_WRITE, idx, val)
+
+s.sendto(req, addr)
+res, addr2 = s.recvfrom(1024)
+
+op_type, idx2, val2 = hdr.unpack(res)
+
+print idx2, val2


### PR DESCRIPTION
An example of how to read and write registers from a P4 program.

The P4Runtime in BMV2 doesn't support reading/writing registers yet. Once there is support for that, we should update this example's `main.py` to show how to read registers from the control plane.