### PR TITLE
Replace mark_to_drop() with mark_to_drop(standard_metadata)

### DIFF
--- a/examples/broadcast.p4app/bcast_router.p4
+++ b/examples/broadcast.p4app/bcast_router.p4
@@ -9,7 +9,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     table send_frame {
         actions = {
@@ -32,7 +32,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;

--- a/examples/customtopo.p4app/simple_router.p4
+++ b/examples/customtopo.p4app/simple_router.p4
@@ -9,7 +9,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -33,7 +33,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     register<bit<32>>(1) forward_count_register;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     action increment_counter() {
         bit<32> forward_count;

--- a/examples/multi_iface.p4app/simple_router.p4
+++ b/examples/multi_iface.p4app/simple_router.p4
@@ -9,7 +9,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -32,7 +32,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;

--- a/examples/multiswitch.p4app/simple_router.p4
+++ b/examples/multiswitch.p4app/simple_router.p4
@@ -9,7 +9,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -32,7 +32,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;

--- a/examples/paxos_acceptor.p4app/acceptor.p4
+++ b/examples/paxos_acceptor.p4app/acceptor.p4
@@ -84,7 +84,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
 
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     action set_UDPdstPort(bit<16> dstPort) {

--- a/examples/simple_router.p4app/simple_router.p4
+++ b/examples/simple_router.p4app/simple_router.p4
@@ -9,7 +9,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     table send_frame {
         actions = {
@@ -32,7 +32,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;


### PR DESCRIPTION
```sh
$ ./p4app run examples/simple_router.p4app
Entering build directory.
Extracting package.
> touch /tmp/p4app_logs/p4s.s1.log
> ln -s /tmp/p4app_logs/p4s.s1.log /tmp/p4s.s1.log
Reading package manifest.
> p4c-bm2-ss --p4v 16 "simple_router.p4" -o "simple_router.json"
simple_router.p4(12): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
        mark_to_drop();
        ^^^^^^^^^^^^
/usr/local/share/p4c/p4include/v1model.p4(343)
extern void mark_to_drop();
            ^^^^^^^^^^^^
simple_router.p4(35): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
        mark_to_drop();
        ^^^^^^^^^^^^
/usr/local/share/p4c/p4include/v1model.p4(343)
extern void mark_to_drop();
            ^^^^^^^^^^^^
simple_router.p4(12): [--Werror=target-error] error: mark_to_drop: Unsupported on target Expected 1 argument for mark_to_drop. Are you using an up-to-date v1model.p4?
        mark_to_drop();
        ^^^^^^^^^^^^^^
simple_router.p4(35): [--Werror=target-error] error: mark_to_drop: Unsupported on target Expected 1 argument for mark_to_drop. Are you using an up-to-date v1model.p4?
        mark_to_drop();
        ^^^^^^^^^^^^^^
Compile failed.
```

Replacing `mark_to_drop()` with `mark_to_drop(standard_metadata)` resolves this issue.